### PR TITLE
Capture device logs for test runs

### DIFF
--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -4,6 +4,9 @@ BeforeAll do
   # start the simulator
   Maze::Runner.run_command("kepler device simulator start")
 
+  # start the simulator log stream
+  Maze::Runner.run_command("kepler device start-log-stream -d Simulator > device.log", blocking: false)
+
   # install the app
   Maze::Runner.run_command("kepler device uninstall-app -d Simulator -a com.bugsnag.fixtures.keplertestapp.main")
   Maze::Runner.run_command("kepler device install-app -d Simulator --dir features/fixtures/keplertestapp")
@@ -12,6 +15,9 @@ end
 AfterAll do
   # stop the simulator
   Maze::Runner.run_command("kepler device simulator stop")
+
+  # move device logs to maze_output
+  Maze::Runner.run_command("mv device.log maze_output")
 end
 
 Maze.hooks.before do


### PR DESCRIPTION
## Goal

Adds device logs to the maze runner test output

## Design

The log stream is started in the `BeforeAll` hook as I thought it would be useful to capture logs from the app install as well. Logs are piped to `test/device.log` and then copied to the `maze_output` directory at the end of the test run because it looks like maze runner clears the `maze_output` after the `BeforeAll` hook runs