### PR TITLE
Uninstall signal handlers before delegating to previous handlers

### DIFF
--- a/packages/kepler-native/kepler/turbo-modules/BugsnagClient.cpp
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagClient.cpp
@@ -5,10 +5,8 @@ Client *global_client;
 
 Client::Client(std::unique_ptr<Configuration> config) :
     config(std::move(config)),
-    event_filename(config->storage_dir),
+    event_dir(config->storage_dir),
     is_launching(true) {
-
-   event_filename.append("crashfile.txt");
 }
 
 void Client::markLaunchCompleted() {

--- a/packages/kepler-native/kepler/turbo-modules/BugsnagClient.h
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagClient.h
@@ -15,7 +15,7 @@ public:
 
     void markLaunchCompleted();
 
-    std::string event_filename;
+    std::string event_dir;
 private:
     std::atomic<bool> is_launching;
     std::unique_ptr<Configuration> config;

--- a/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
+++ b/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
@@ -10,7 +10,7 @@ export interface BugsnagKeplerNative extends KeplerTurboModule {
   // Exported methods.
   configure: (configuration: BugsnagConfiguration) => void
   markLaunchCompleted: () => void
-  nativeCrash:() => void
+  nativeCrash: () => void
 }
 
 // prettier-ignore


### PR DESCRIPTION
## Goal
Improve native crash debugging (while `@bugsnag/kepler` is in development) by handling crash loops and crash-on-crash events.

## Design
Added a counter to the crash filename, this is placed in a fixed size buffer *with no overflow defense*. This is just to keep things simple for now, as this code will be completely replaced later on (when we have a more structured error handler).

Added a simple boolean check when installing the signal handlers to ensure they are only installed once.

Uninstall our signal handlers before delegating to the previously registered ones, in order to avoid putting the process into a crash loop.

## Testing
Manually tested