### PR TITLE
Add context e2e tests

### DIFF
--- a/test/features/context.feature
+++ b/test/features/context.feature
@@ -1,0 +1,10 @@
+Feature: Context
+
+Scenario: JS custom context
+  When I run "ContextJsCustomScenario"
+  And I wait to receive 3 errors
+  Then the received errors match:
+    | exceptions.0.errorClass | exceptions.0.message     | context          | 
+    | Error                   | ContextJsCustomScenarioA | context-config   |
+    | Error                   | ContextJsCustomScenarioB | context-client   | 
+    | Error                   | ContextJsCustomScenarioC | context-onerror  |

--- a/test/features/fixtures/keplertestapp/src/scenarios/ContextJsCustomScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/ContextJsCustomScenario.tsx
@@ -1,0 +1,40 @@
+import Bugsnag from '@bugsnag/kepler'
+import React, { useEffect } from 'react'
+import { Text, View } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+
+const config = {
+    context: 'context-config'
+}
+
+const App = () => {
+    const styles = getStyles()
+
+    useEffect(() => {
+        Bugsnag.notify(new Error('ContextJsCustomScenarioA'), () => {
+        }, () => {
+          setTimeout(() => {
+            Bugsnag.setContext('context-client')
+            Bugsnag.notify(new Error('ContextJsCustomScenarioB'), () => {
+              setTimeout(() => {
+                Bugsnag.notify(new Error('ContextJsCustomScenarioC'), event => {
+                  event.context = 'context-onerror'
+                })
+              }, 500)
+            })
+          }, 500)
+        })
+    }, [])
+
+    return (
+        <View style={styles.background}>
+            <View style={styles.headerContainer}>
+                <Text style={styles.headerText}>ContextJsCustomScenario</Text>
+            </View>
+        </View>
+    )
+}
+
+export default { App, config }
+
+

--- a/test/features/fixtures/keplertestapp/src/scenarios/index.ts
+++ b/test/features/fixtures/keplertestapp/src/scenarios/index.ts
@@ -2,3 +2,4 @@ export { default as HandledJsErrorScenario } from './HandledJsErrorScenario';
 export { default as ManualBreadcrumbScenario } from './ManualBreadcrumbScenario';
 export { default as UnhandledPromiseRejectionScenario } from './UnhandledPromiseRejectionScenario';
 export { default as ConsoleBreadcrumbScenario } from './ConsoleBreadcrumbScenario';
+export { default as ContextJsCustomScenario } from './ContextJsCustomScenario';

--- a/test/features/handled.feature
+++ b/test/features/handled.feature
@@ -7,6 +7,7 @@ Scenario: Calling notify() with a caught Error
   And the exception "type" equals "reactnativejs"
   And the exception "message" equals "HandledJSError"
   And the event "unhandled" is false
+  And the event "context" is null
 
 Scenario: Errors are stored when the network is unreachable
   # make the network unreachable


### PR DESCRIPTION
## Goal

Add e2e tests for setting context manually - covers setting context via config, `setContext` and from an `onError` callback