### PR TITLE
Avoid getCommand errors breaking tests

### DIFF
--- a/test/features/fixtures/keplertestapp/src/commandRunner.ts
+++ b/test/features/fixtures/keplertestapp/src/commandRunner.ts
@@ -3,6 +3,7 @@ import { startBugsnag } from "./commands/startBugsnag"
 import { getCommand } from "./getCommand"
 import delay from "./utils/delay"
 import { clearLastCommandUUID, getLastCommandUUID, setLastCommandUUID } from "./utils/storage"
+import {Command} from "../types";
 
 const COMMAND_INTERVAL = 500
 

--- a/test/features/fixtures/keplertestapp/src/getCommand.ts
+++ b/test/features/fixtures/keplertestapp/src/getCommand.ts
@@ -1,7 +1,6 @@
 import type { Command } from "../types"
 import delay from './utils/delay'
 
-const DEFAULT_RETRY_COUNT = 20
 const INTERVAL = 500
 
 function getErrorMessage(error: unknown) {
@@ -9,14 +8,13 @@ function getErrorMessage(error: unknown) {
     return String(error)
 }
 
-export async function getCommand (mazeAddress = '10.0.2.2:9339', allowedRetries = DEFAULT_RETRY_COUNT): Promise<Command> {
+export async function getCommand (mazeAddress = '10.0.2.2:9339'): Promise<Command> {
     // poll the server for the next command to run
     const mazeUrl = `http://${mazeAddress}/command`
 
     console.log('[Bugsnag] getCommand entered!')
 
-    let retries = 0
-    while (retries++ < allowedRetries) {
+    while (true) {
         try {
             console.log('[Bugsnag] Fetching command from maze')
             const response = await fetch(mazeUrl)
@@ -33,6 +31,4 @@ export async function getCommand (mazeAddress = '10.0.2.2:9339', allowedRetries 
         }
       await delay(INTERVAL)
     }
-
-    throw new Error('Retry limit exceeded, giving up...')
 }


### PR DESCRIPTION
## Goal
Avoid "Retry limit exceeded, giving up..." errors leaking into error reports in scenarios that require large amounts of time to process.

## Design
The `getCommand()` function no longer has an `allowedRetries` limit, and will retry until it gets a valid command or the fixture is terminated. This is inline with the other platforms.
