### PR TITLE
Add the binaryArch field to the `event.app` properties

### DIFF
--- a/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.cpp
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.cpp
@@ -14,26 +14,54 @@
 #define TM_API_NAMESPACE com::amazon::kepler::turbomodule
 
 namespace bugsnag {
+static utils::json::JsonContainer createStaticApp() {
+  auto app = utils::json::JsonContainer::createJsonObject();
+
+  #if defined(__i386__)
+    const char *binary_arch = "x86";
+  #elif defined(__x86_64__)
+    const char *binary_arch = "x86_64";
+  #elif defined(__arm__)
+    const char *binary_arch = "arm32";
+  #elif defined(__aarch64__)
+    const char *binary_arch = "arm64";
+  #else
+    const char *binary_arch = "unknown";
+  #endif
+  app.insert("binaryArch", std::string(binary_arch));
+
+  return app;
+}
+
 BugsnagKeplerNative::BugsnagKeplerNative() :
         TM_API_NAMESPACE::KeplerTurboModule("BugsnagKeplerNative") {}
 
 void BugsnagKeplerNative::aggregateMethods(TM_API_NAMESPACE::MethodAggregator<TM_API_NAMESPACE::KeplerTurboModule>& methodAggregator) const noexcept {
-    methodAggregator.addMethod("configure", 1, &BugsnagKeplerNative::configure);
-    methodAggregator.addMethod("nativeCrash", 0, &BugsnagKeplerNative::nativeCrash);
+  methodAggregator.addMethod("configure", 1, &BugsnagKeplerNative::configure);
+  methodAggregator.addMethod("markLaunchCompleted", 0, &BugsnagKeplerNative::markLaunchCompleted);
+  methodAggregator.addMethod("nativeCrash", 0, &BugsnagKeplerNative::nativeCrash);
 }
 
 utils::json::JsonContainer BugsnagKeplerNative::configure(utils::json::JsonContainer config) {
-    auto bsg_config = std::make_unique<Configuration>();
-    bsg_config->storage_dir = std::string("/data/");
+  auto bsg_config = std::make_unique<Configuration>();
+  bsg_config->storage_dir = std::string("/data/");
 
-    Client *c = new Client(std::move(bsg_config));
-    global_client = c;
+  Client *c = new Client(std::move(bsg_config));
+  global_client = c;
 
-    install_signal_handlers();
+  install_signal_handlers();
 
-    auto result = utils::json::JsonContainer::createJsonObject();
+  auto result = utils::json::JsonContainer::createJsonObject();
+  result.insert("app", createStaticApp());
 
-    return result;
+  return result;
+}
+
+void BugsnagKeplerNative::markLaunchCompleted() {
+  auto client = this->bugsnag;
+  if (client != nullptr) {
+    client->markLaunchCompleted();
+  }
 }
 
 // Temporary native crash that can be used for testing:

--- a/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.h
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.h
@@ -15,6 +15,7 @@ namespace bugsnag {
         void nativeCrash();
 
         utils::json::JsonContainer configure(utils::json::JsonContainer config);
+        void markLaunchCompleted();
 
       private:
         Client *bugsnag;

--- a/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
+++ b/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
@@ -6,9 +6,17 @@ interface BugsnagConfiguration {
   appVersion?: string
 }
 
+interface NativeStaticApp {
+  binaryArch: string
+}
+
+interface BugsnagNativeStaticInfo {
+  app: NativeStaticApp
+}
+
 export interface BugsnagKeplerNative extends KeplerTurboModule {
   // Exported methods.
-  configure: (configuration: BugsnagConfiguration) => void
+  configure: (configuration: BugsnagConfiguration) => BugsnagNativeStaticInfo
   markLaunchCompleted: () => void
   nativeCrash: () => void
 }

--- a/packages/kepler/lib/notifier.js
+++ b/packages/kepler/lib/notifier.js
@@ -14,6 +14,12 @@ const url = 'https://github.com/bugsnag/bugsnag-kepler'
 
 Event.__type = 'reactnativejs'
 
+const keplerEventFactory = (createCoreEvent, nativeStateInfo) => (...createEventArgs) => {
+  const event = createCoreEvent(...createEventArgs)
+  Object.assign(event.app, nativeStateInfo.app)
+  return event
+}
+
 export const Bugsnag = {
   _client: null,
   createClient: (opts) => {
@@ -30,9 +36,11 @@ export const Bugsnag = {
 
     // configure a client with user supplied options
     const bugsnag = new Client(opts, schema, internalPlugins, { name, version, url })
-    BugsnagKeplerNative.configure({
+    const nativeStaticInfo = BugsnagKeplerNative.configure({
       apiKey: opts.apiKey
     })
+
+    Event.create = keplerEventFactory(Event.create, nativeStaticInfo)
 
     bugsnag._setDelivery(delivery)
     bugsnag.markLaunchComplete = () => {

--- a/packages/kepler/tests/__mocks__/@bugsnag/kepler-native.ts
+++ b/packages/kepler/tests/__mocks__/@bugsnag/kepler-native.ts
@@ -10,5 +10,5 @@ export const BugsnagFileIO = {
 
 
 export const BugsnagKeplerNative = {
-  configure: jest.fn(),
+  configure: jest.fn().mockReturnValue({app: {}}),
 }

--- a/test/features/handled.feature
+++ b/test/features/handled.feature
@@ -8,6 +8,7 @@ Scenario: Calling notify() with a caught Error
   And the exception "message" equals "HandledJSError"
   And the event "unhandled" is false
   And the event "context" is null
+  And the event "app.binaryArch" is not null
 
 Scenario: Errors are stored when the network is unreachable
   # make the network unreachable


### PR DESCRIPTION
## Goal
Add the binaryArch field to `event.app`, the field should reflect the binary architecture of the native *code* that is running  as apposed to the `cpuAbi` (which is a different `device` field not included in this PR).

## Design
The `BugsnagKeplerNative.configure` function now returns an object containing any static data that can be discovered from the native layer, and added to an `Event`.

The `Event.create` function is replaced with a Kepler-specific wrapper that can be used to add in the Kepler attributes.

## Testing
Added a test to mazerunner and verified it manually