### PR TITLE
Add React error boundary e2e test

### DIFF
--- a/test/features/error_boundary.feature
+++ b/test/features/error_boundary.feature
@@ -1,0 +1,8 @@
+Feature: Capturing render errors
+
+Scenario: Render errors are captured by the ErrorBoundary
+  When I run "ErrorBoundaryScenario"
+  And I wait to receive an error
+  Then the exception "errorClass" equals "Error"
+  And the exception "message" equals "render error"
+  And the event "metaData.react.componentStack" is not null

--- a/test/features/fixtures/keplertestapp/src/scenarios/ErrorBoundaryScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/ErrorBoundaryScenario.tsx
@@ -1,0 +1,48 @@
+import Bugsnag, { type Event } from '@bugsnag/kepler'
+import React, { useEffect } from 'react'
+import { Text, View, Button } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+
+const config = {}
+
+interface ErrorViewProps {
+    clearError: () => void
+}
+
+const ErrorView = ({ clearError }: ErrorViewProps) =>
+<View>
+    <Text>Inform users of an error in the component tree.
+    Use clearError to reset ErrorBoundary state and re-render child tree.</Text>
+    <Button onPress={clearError} title="Reset" />
+</View>
+
+const onError = (event: Event) => {
+    console.log('ErrorBoundary onError')
+}
+
+const BadComponent = () => {
+    throw new Error('render error')
+}
+
+const App = () => {
+    const styles = getStyles()
+
+    const ErrorBoundary = Bugsnag.getPlugin('react').createErrorBoundary(React)
+
+    useEffect(() => {
+        console.log('ErrorBoundaryScenario useEffect');
+      }, []);
+
+    return (
+        <ErrorBoundary FallbackComponent={ErrorView} onError={onError}>
+            <View style={styles.background}>
+                <View style={styles.headerContainer}>
+                    <Text style={styles.headerText}>ErrorBoundaryScenario</Text>
+                    <BadComponent />
+                </View>
+            </View>
+        </ErrorBoundary>
+    )
+}
+
+export default { App, config }

--- a/test/features/fixtures/keplertestapp/src/scenarios/index.ts
+++ b/test/features/fixtures/keplertestapp/src/scenarios/index.ts
@@ -14,4 +14,5 @@ export { default as DisabledBreadcrumbScenario } from './DisabledBreadcrumbScena
 export { default as MaxBreadcrumbScenario } from './MaxBreadcrumbScenario';
 export { default as ReleaseStageEnabledScenario } from './ReleaseStageEnabledScenario';
 export { default as ReleaseStageDisabledScenario } from './ReleaseStageDisabledScenario';
+export { default as ErrorBoundaryScenario } from './ErrorBoundaryScenario';
 


### PR DESCRIPTION
## Goal

Adds e2e test for capturing render errors using the `ErrorBoundary` component

Also updates the stored events test to assert that delivery correctly handles notify calls while a request is already in-flight (see #27)