### PR TITLE
Add tests for autoDetectErrors and enabledErrorTypes config

### DIFF
--- a/test/features/auto_detect_errors.feature
+++ b/test/features/auto_detect_errors.feature
@@ -1,0 +1,17 @@
+Feature: Switching off automatic reporting
+
+Scenario: setting autoDetectErrors option to false
+  When I run "AutoDetectErrorsScenario"
+  And I wait for 5 seconds
+  Then I wait to receive an error
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "manual notify does work"
+
+Scenario: setting enabledErrorTypes.unhandledRejections option to false
+  When I run "UnhandledPromiseRejectionsDisabledScenario"
+  And I wait for 5 seconds
+  Then I wait to receive an error
+  And the event "unhandled" is false
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "manual notify does work"

--- a/test/features/fixtures/keplertestapp/src/scenarios/AutoDetectErrorsScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/AutoDetectErrorsScenario.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react'
+import { Text, View } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+import Bugsnag, { type KeplerConfig } from '@bugsnag/kepler'
+
+const config: Partial<KeplerConfig> = {
+  autoDetectErrors: false
+}
+
+const App = () => {
+  const styles = getStyles()
+
+  useEffect(() => {
+      Bugsnag.notify(new Error('manual notify does work'))
+
+      Promise.reject(new Error('UnhandledPromiseRejectionsDisabledScenario'))
+  }, [])
+
+  return (
+      <View style={styles.background}>
+          <View style={styles.headerContainer}>
+              <Text style={styles.headerText}>UnhandledPromiseRejectionsDisabledScenario</Text>
+          </View>
+      </View>
+  )
+}
+
+export default { App, config }
+

--- a/test/features/fixtures/keplertestapp/src/scenarios/ErrorBoundaryScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/ErrorBoundaryScenario.tsx
@@ -1,5 +1,5 @@
 import Bugsnag, { type Event } from '@bugsnag/kepler'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Text, View, Button } from "react-native"
 import { getStyles } from '../utils/defaultStyle'
 
@@ -28,10 +28,6 @@ const App = () => {
     const styles = getStyles()
 
     const ErrorBoundary = Bugsnag.getPlugin('react').createErrorBoundary(React)
-
-    useEffect(() => {
-        console.log('ErrorBoundaryScenario useEffect');
-      }, []);
 
     return (
         <ErrorBoundary FallbackComponent={ErrorView} onError={onError}>

--- a/test/features/fixtures/keplertestapp/src/scenarios/UnhandledPromiseRejectionsDisabledScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/UnhandledPromiseRejectionsDisabledScenario.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react'
+import { Text, View } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+import Bugsnag, { type KeplerConfig } from '@bugsnag/kepler'
+
+const config: Partial<KeplerConfig> = {
+  enabledErrorTypes: {
+    unhandledRejections: false
+  }
+}
+
+const App = () => {
+    const styles = getStyles()
+
+    useEffect(() => {
+        Bugsnag.notify(new Error('manual notify does work'))
+
+        Promise.reject(new Error('UnhandledPromiseRejectionsDisabledScenario'))
+    }, [])
+
+    return (
+        <View style={styles.background}>
+            <View style={styles.headerContainer}>
+                <Text style={styles.headerText}>UnhandledPromiseRejectionsDisabledScenario</Text>
+            </View>
+        </View>
+    )
+}
+
+export default { App, config }
+

--- a/test/features/fixtures/keplertestapp/src/scenarios/index.ts
+++ b/test/features/fixtures/keplertestapp/src/scenarios/index.ts
@@ -19,4 +19,6 @@ export { default as HandledOverrideJsErrorScenario } from './HandledOverrideJsEr
 export { default as UnhandledOverrideJsErrorScenario } from './UnhandledOverrideJsErrorScenario';
 export { default as NavigationBreadcrumbScenario } from './NavigationBreadcrumbScenario';
 export { default as NavigationCrumbsDisabledScenario } from './NavigationCrumbsDisabledScenario';
+export { default as AutoDetectErrorsScenario } from './AutoDetectErrorsScenario';
+export { default as UnhandledPromiseRejectionsDisabledScenario } from './UnhandledPromiseRejectionsDisabledScenario';
 export { default as MaxPersistedEventsScenario } from './MaxPersistedEventsScenario';


### PR DESCRIPTION
## Goal

Add tests for `autoDetectErrors` and `enabledErrorTypes.unhandledRejections` config options.

Since we can't currently test unhandled errors easily, I haven't included `enabledErrorTypes.unhandledExceptions` here - this will be added when we add the unhandled errors tests