### PR TITLE
Add basic device metadata

### DIFF
--- a/packages/kepler/lib/device.js
+++ b/packages/kepler/lib/device.js
@@ -1,0 +1,37 @@
+import { Platform } from 'react-native'
+
+const getEngine = () => global.HermesInternal ? 'hermes' : 'unknown'
+
+const getReactNativeVersion = () => {
+  const { major, minor, patch } = Platform.constants.reactNativeVersion
+  return `${major}.${minor}.${patch}`
+}
+
+const pluginDevice = {
+  load: (client) => {
+    const device = {
+      osName: 'kepler',
+      runtimeVersions: {
+        reactNative: getReactNativeVersion(),
+        reactNativeJsEngine: getEngine()
+      }
+    }
+
+    client.addOnSession(session => {
+      session.device = {
+        ...session.device,
+        ...device
+      }
+    })
+
+    client.addOnError((event) => {
+      event.device = {
+        ...event.device,
+        ...device,
+        time: new Date()
+      }
+    }, true)
+  }
+}
+
+export default pluginDevice

--- a/packages/kepler/lib/notifier.js
+++ b/packages/kepler/lib/notifier.js
@@ -10,6 +10,7 @@ import pluginConsoleBreadcrumbs from '@bugsnag/plugin-console-breadcrumbs'
 import createPluginNetworkBreadcrumbs from '@bugsnag/plugin-network-breadcrumbs'
 import pluginSession from '@bugsnag/plugin-browser-session'
 import React from 'react'
+import pluginDevice from './device'
 
 const name = 'Bugsnag Kepler'
 const url = 'https://github.com/bugsnag/bugsnag-kepler'
@@ -35,6 +36,7 @@ export const Bugsnag = {
       pluginConsoleBreadcrumbs,
       createPluginNetworkBreadcrumbs(),
       pluginSession,
+      pluginDevice,
       new BugsnagPluginReact(React)
     ]
 

--- a/packages/kepler/tests/__mocks__/react-native.ts
+++ b/packages/kepler/tests/__mocks__/react-native.ts
@@ -1,0 +1,24 @@
+type ReactNativeVersion = {
+  major: number,
+  minor: number,
+  patch: number,
+  prerelease?: number | null | undefined
+}
+
+type PlatformConstants = { reactNativeVersion: ReactNativeVersion }
+
+export const Platform = new class {
+  get OS (): 'kepler' {
+    return 'kepler'
+  }
+
+  get constants (): PlatformConstants {
+    return {
+      reactNativeVersion: {
+        major: 0,
+        minor: 72,
+        patch: 0
+      }
+    }
+  }
+}()

--- a/packages/kepler/tests/device.test.ts
+++ b/packages/kepler/tests/device.test.ts
@@ -1,0 +1,76 @@
+import plugin from '../lib/device'
+import { Client } from '@bugsnag/core'
+
+// @ts-expect-error cannot find global
+global.HermesInternal = {}
+
+interface Device {
+  osName: string,
+    runtimeVersions: {
+      reactNative: string,
+      reactNativeJsEngine: string
+    }
+}
+
+interface DeviceWithState extends Device {
+  time: Date
+}
+
+interface EventWithDevice {
+  device: DeviceWithState
+}
+
+interface SessionWithDevice {
+  device: Device
+}
+
+interface EventPayload {
+  events: EventWithDevice[]
+}
+
+describe('device plugin', () => {
+  it('should add an onError callback which captures device information', () => {
+    // @ts-expect-error client constructor is protected
+    const client = new Client({ apiKey: 'API_KEY_YEAH' }, undefined, [plugin])
+    const payloads: EventPayload[] = []
+
+    expect(client._cbs.e).toHaveLength(1)
+
+    // 
+    client._setDelivery(() => ({ sendEvent: (payload: EventPayload) => payloads.push(payload), sendSession: () => {} }))
+    client.notify(new Error('noooo'))
+
+    expect(payloads.length).toEqual(1)
+    expect(payloads[0].events[0].device).toBeDefined()
+    expect(payloads[0].events[0].device.time instanceof Date).toBe(true)
+    expect(payloads[0].events[0].device.runtimeVersions).toBeDefined()
+    expect(payloads[0].events[0].device.runtimeVersions.reactNative).toBe('0.72.0')
+    expect(payloads[0].events[0].device.runtimeVersions.reactNativeJsEngine).toBe('hermes')
+    expect(payloads[0].events[0].device.osName).toBe('kepler')
+  })
+
+  it('should add an onSession callback which captures device information', () => {
+    // @ts-expect-error client constructor is protected
+    const client = new Client({ apiKey: 'API_KEY_YEAH' }, undefined, [plugin])
+    const payloads: SessionWithDevice[] = []
+    client._sessionDelegate = {
+      startSession: (client: any, session: SessionWithDevice) => {
+        client._delivery.sendSession(session, () => {})
+
+        return client
+      }
+    }
+
+    expect(client._cbs.s).toHaveLength(1)
+
+    client._setDelivery(() => ({ sendEvent: () => {}, sendSession: (payload: SessionWithDevice) => payloads.push(payload) }))
+    client.startSession()
+
+    expect(payloads.length).toEqual(1)
+    expect(payloads[0].device).toBeDefined()
+    expect(payloads[0].device.runtimeVersions).toBeDefined()
+    expect(payloads[0].device.runtimeVersions.reactNative).toBe('0.72.0')
+    expect(payloads[0].device.runtimeVersions.reactNativeJsEngine).toBe('hermes')
+    expect(payloads[0].device.osName).toBe('kepler')
+  })
+})

--- a/test/features/handled.feature
+++ b/test/features/handled.feature
@@ -9,6 +9,10 @@ Scenario: Calling notify() with a caught Error
   And the event "unhandled" is false
   And the event "context" is null
   And the event "app.binaryArch" is not null
+  And the event "device.time" is not null
+  And the event "device.runtimeVersions.reactNative" is not null
+  And the event "device.runtimeVersions.reactNativeJsEngine" equals "hermes"
+  And the event "device.osName" equals "kepler"
 
 Scenario: Errors are stored when the network is unreachable
   # make the network unreachable

--- a/test/features/session.feature
+++ b/test/features/session.feature
@@ -5,10 +5,12 @@ Scenario: Automatic sessions enabled by default
   And I wait to receive a session
   Then the session is valid for the session reporting API version "1" for the "Bugsnag Kepler" notifier
   And the session payload has a valid sessions array
+  And the session payload field "device.runtimeVersions.reactNative" is not null
+  And the session payload field "device.runtimeVersions.reactNativeJsEngine" equals "hermes"
+  And the session payload field "device.osName" equals "kepler"
 
 Scenario: Automatic sessions disabled
   When I run "SessionAutoDisabledScenario"
-  And I wait for 5 seconds
   Then I should receive no sessions
 
 Scenario: Manual sessions


### PR DESCRIPTION
## Goal

Adds the following device metadata to events and sessions:

- `device.runtimeVersions.reactNative`
- `device.runtimeVersions.reactNativeJsEngine`
- `device.osName`
- `device.time` (events only)

## Testing
Added new unit tests and updated e2e test assertions