### PR TITLE
[PLAT-11795] Add end to end tests for metadata

### DIFF
--- a/test/features/fixtures/keplertestapp/src/scenarios/AddMetadataScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/AddMetadataScenario.tsx
@@ -1,0 +1,34 @@
+import Bugsnag, { type KeplerConfig } from '@bugsnag/kepler'
+import React, { useEffect } from 'react'
+import { Text, View } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+
+const config: Partial<KeplerConfig> = {
+    metadata: {
+        config: {
+            key: 'value'
+        }
+    }
+}
+
+const App = () => {
+    const styles = getStyles()
+
+    useEffect(() => {
+        Bugsnag.addMetadata('add_metadata', 'key', 'value')
+        Bugsnag.addMetadata('metadata_section', {'key': 'value'})
+        Bugsnag.notify(new Error('AddMetadata'), (event) => {
+            event.addMetadata('event_add_metadata', 'key', 'value')
+        })
+    }, [])
+
+    return (
+        <View style={styles.background}>
+            <View style={styles.headerContainer}>
+                <Text style={styles.headerText}>AddMetadataScenario</Text>
+            </View>
+        </View>
+    )
+}
+
+export default { App, config }

--- a/test/features/fixtures/keplertestapp/src/scenarios/RedactMetadataScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/RedactMetadataScenario.tsx
@@ -1,0 +1,35 @@
+import Bugsnag, { type KeplerConfig } from '@bugsnag/kepler'
+import React, { useEffect } from 'react'
+import { Text, View } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+
+const config: Partial<KeplerConfig> = {
+    redactedKeys: ['key'],
+    metadata: {
+        config: {
+            key: 'value'
+        }
+    }
+}
+
+const App = () => {
+    const styles = getStyles()
+
+    useEffect(() => {
+        Bugsnag.addMetadata('add_metadata', 'key', 'value')
+        Bugsnag.addMetadata('metadata_section', {'key': 'value'})
+        Bugsnag.notify(new Error('AddMetadata'), (event) => {
+            event.addMetadata('event_add_metadata', 'key', 'value')
+        })
+    }, [])
+
+    return (
+        <View style={styles.background}>
+            <View style={styles.headerContainer}>
+                <Text style={styles.headerText}>RedactMetadataScenario</Text>
+            </View>
+        </View>
+    )
+}
+
+export default { App, config }

--- a/test/features/fixtures/keplertestapp/src/scenarios/index.ts
+++ b/test/features/fixtures/keplertestapp/src/scenarios/index.ts
@@ -22,3 +22,5 @@ export { default as NavigationCrumbsDisabledScenario } from './NavigationCrumbsD
 export { default as AutoDetectErrorsScenario } from './AutoDetectErrorsScenario';
 export { default as UnhandledPromiseRejectionsDisabledScenario } from './UnhandledPromiseRejectionsDisabledScenario';
 export { default as MaxPersistedEventsScenario } from './MaxPersistedEventsScenario';
+export { default as AddMetadataScenario } from './AddMetadataScenario';
+export { default as RedactMetadataScenario } from './RedactMetadataScenario';

--- a/test/features/metadata.feature
+++ b/test/features/metadata.feature
@@ -1,0 +1,17 @@
+Feature: Metadata
+
+Scenario: Calling addMetadata with a key/value pair shall add the data to the stored metadata for the specified section
+  When I run "AddMetadataScenario"
+  And I wait to receive an error
+  Then the event "metaData.config.key" equals "value"
+  And the event "metaData.add_metadata.key" equals "value"
+  And the event "metaData.event_add_metadata.key" equals "value"
+  And the event "metaData.metadata_section.key" equals "value"
+
+Scenario: The notifier shall redact the value of any MetadataSection where the key matches any strings or regexes in the list of redactedKeys configuration property
+  When I run "RedactMetadataScenario"
+  And I wait to receive an error
+  Then the event "metaData.config.key" equals "[REDACTED]"
+  And the event "metaData.add_metadata.key" equals "[REDACTED]"
+  And the event "metaData.event_add_metadata.key" equals "[REDACTED]"
+  And the event "metaData.metadata_section.key" equals "[REDACTED]"


### PR DESCRIPTION
Add smoke tests for adding metadata via `Bugsnag.addMetadata` and `event.addMetadata` in the callback passed to `Bugsnag.notify` and redacting their values by `redactedKeys` config value