### PR TITLE
Set default release stage based on __DEV__

### DIFF
--- a/packages/kepler/lib/config.js
+++ b/packages/kepler/lib/config.js
@@ -1,13 +1,23 @@
+/* global __DEV__ */
+
 import { schema as coreSchema } from '@bugsnag/core/config'
 import intRange from '@bugsnag/core/lib/validators/int-range'
 
 const iserror = require('iserror')
+
+const IS_PRODUCTION = typeof __DEV__ === 'undefined' || __DEV__ !== true
 
 export const schema = {
   ...coreSchema,
   logger: {
     ...coreSchema.logger,
     defaultValue: () => getPrefixedConsole()
+  },
+  releaseStage: {
+    ...coreSchema.releaseStage,
+    defaultValue: () => {
+      return IS_PRODUCTION ? 'production' : 'development'
+    }
   },
   persistenceDirectory: {
     defaultValue: () => '/data/bugsnag',

--- a/packages/kepler/tests/config.test.ts
+++ b/packages/kepler/tests/config.test.ts
@@ -39,4 +39,21 @@ describe('kepler config', () => {
       expect(console.warn).toHaveBeenCalledWith('[bugsnag]', 'oh no')
     })
   })
+
+  describe('releaseStage', () => {
+    it('sets a default value for releaseStage correctly', () => {
+
+      // @ts-expect-error __DEV__ is a const
+      __DEV__ = false
+      let config = require('../lib/config').default
+      expect(config.releaseStage.defaultValue()).toBe('production')
+
+      jest.resetModules()
+
+      // @ts-expect-error __DEV__ is a const
+      __DEV__ = true
+      config = require('../lib/config').default
+      expect(config.releaseStage.defaultValue()).toBe('development')
+    })
+  })
 })


### PR DESCRIPTION
## Goal

Sets the default release stage to `development` if the global `__DEV__` === true. 

In a kepler app this is set to `true` if the app is built in debug mode, i.e. `kepler build -b Debug`

## Testing

Added unit tests and manually tested in a kepler sample app (since the e2e tests use a release build)