### PR TITLE
Add handling for feature flags to kepler native

### DIFF
--- a/packages/kepler-native/kepler/turbo-modules/BugsnagClient.cpp
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagClient.cpp
@@ -34,4 +34,23 @@ std::string Client::getMetadata() {
 }
 
 void Client::clearMetadata() { this->metadata.reset(nullptr); }
+
+void Client::addFeatures(std::string featuresStr) {
+  char *newFeatures = strdup(featuresStr.c_str());
+  this->features.reset(newFeatures);
+}
+
+std::string Client::getFeatures() {
+  std::string featuresStr;
+  char *featuresChar = this->features.acquire();
+  if (featuresChar != nullptr) {
+    featuresStr = std::string(featuresChar);
+  }
+
+  this->features.release();
+
+  return featuresStr;
+}
+
+void Client::clearFeatures() { this->features.reset(nullptr); }
 } // namespace bugsnag

--- a/packages/kepler-native/kepler/turbo-modules/BugsnagClient.h
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagClient.h
@@ -24,6 +24,10 @@ public:
   std::string getMetadata();
   void clearMetadata();
 
+  void addFeatures(std::string featuresStr);
+  std::string getFeatures();
+  void clearFeatures();
+
   std::string event_dir;
 
 private:
@@ -31,6 +35,7 @@ private:
   std::unique_ptr<Configuration> config;
   BreadcrumbBuffer breadcrumb_buffer;
   SafeSharedPtr<char> metadata;
+  SafeSharedPtr<char> features;
 };
 
 extern Client *global_client;

--- a/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.cpp
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.cpp
@@ -57,6 +57,10 @@ void BugsnagKeplerNative::aggregateMethods(
                              &BugsnagKeplerNative::addMetadata);
   methodAggregator.addMethod("clearMetadata", 0,
                              &BugsnagKeplerNative::clearMetadata);
+  methodAggregator.addMethod("addFeatures", 1,
+                             &BugsnagKeplerNative::addFeatures);
+  methodAggregator.addMethod("clearFeatures", 0,
+                             &BugsnagKeplerNative::clearFeatures);
   methodAggregator.addMethod("nativeCrash", 0,
                              &BugsnagKeplerNative::nativeCrash);
 }
@@ -128,6 +132,12 @@ void BugsnagKeplerNative::addMetadata(std::string metadataStr) {
 }
 
 void BugsnagKeplerNative::clearMetadata() { this->bugsnag->clearMetadata(); }
+
+void BugsnagKeplerNative::addFeatures(std::string featuresStr) {
+  this->bugsnag->addFeatures(featuresStr);
+}
+
+void BugsnagKeplerNative::clearFeatures() { this->bugsnag->clearFeatures(); }
 
 // Temporary native crash that can be used for testing:
 

--- a/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.h
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.h
@@ -25,6 +25,8 @@ public:
   void leaveBreadcrumb(utils::json::JsonContainer crumb);
   void addMetadata(std::string metadataStr);
   void clearMetadata();
+  void addFeatures(std::string featuresStr);
+  void clearFeatures();
 
 private:
   Client *bugsnag;

--- a/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
+++ b/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
@@ -31,6 +31,8 @@ export interface BugsnagKeplerNative extends KeplerTurboModule {
   leaveBreadcrumb: (crumb: BugsnagBreadcrumb) => void
   addMetadata(): (metadataStr: string) => void
   clearMetadata(): () => void
+  addFeatures(): (featuresStr: string) => void
+  clearFeatures(): () => void
   nativeCrash: () => void
 }
 

--- a/packages/kepler/lib/features_native.js
+++ b/packages/kepler/lib/features_native.js
@@ -1,0 +1,42 @@
+import { BugsnagKeplerNative } from '@bugsnag/kepler-native'
+import { Client } from '@bugsnag/core'
+
+const nativeFeatures = {
+  register: () => {
+    // wrap add single
+    const origAddOneFeature = Client.prototype.addFeatureFlag
+    Client.prototype.addFeatureFlag = function (...args) {
+      origAddOneFeature.apply(this, args)
+      const featuresAll = this._features
+      const featuresStr = JSON.stringify(featuresAll)
+      BugsnagKeplerNative.addFeatures(featuresStr)
+    }
+
+    // wrap add multiple
+    const origAddMultipleFeatures = Client.prototype.addFeatureFlags
+    Client.prototype.addFeatureFlags = function (...args) {
+      origAddMultipleFeatures.apply(this, args)
+      const featuresAll = this._features
+      const featuresStr = JSON.stringify(featuresAll)
+      BugsnagKeplerNative.addFeatures(featuresStr)
+    }
+
+    // wrap clear
+    const origClearOneFeature = Client.prototype.clearFeatureFlag
+    Client.prototype.clearFeatureFlag = function (...args) {
+      origClearOneFeature.apply(this, args)
+      const metadataAll = this._metadata
+      const metadataStr = JSON.stringify(metadataAll)
+      BugsnagKeplerNative.addFeatures(metadataStr)
+    }
+
+    // wrap clear all
+    const origClearAllFeatures = Client.prototype.clearFeatureFlags
+    Client.prototype.clearFeatureFlags = function (...args) {
+      origClearAllFeatures.apply(this, args)
+      BugsnagKeplerNative.clearFeatures()
+    }
+  }
+}
+
+export default nativeFeatures

--- a/packages/kepler/lib/notifier.js
+++ b/packages/kepler/lib/notifier.js
@@ -16,6 +16,7 @@ import React from 'react'
 import pluginDevice from './device'
 import nativeBreadcrumbs from './breadcrumb_native'
 import nativeMetadata from './metadata_native'
+import nativeFeatureFlags from './features_native'
 
 const name = 'Bugsnag Kepler'
 const url = 'https://github.com/bugsnag/bugsnag-kepler'
@@ -54,6 +55,7 @@ export const Bugsnag = {
 
     nativeBreadcrumbs.register(bugsnag)
     nativeMetadata.register()
+    nativeFeatureFlags.register()
 
     Event.create = keplerEventFactory(Event.create, nativeStaticInfo)
 


### PR DESCRIPTION
Same logic as metadata - just one string on the native side.