### PR TITLE
Add support for running tests on a local device

### DIFF
--- a/test/features/steps/kepler_steps.rb
+++ b/test/features/steps/kepler_steps.rb
@@ -19,16 +19,22 @@ When('I configure the endpoints to default') do
 end
 
 When('I restart the test fixture') do
-  Maze::Runner.run_command("kepler device terminate-app -d Simulator -a com.bugsnag.fixtures.keplertestapp.main")
+  Maze::Runner.run_command("kepler device terminate-app -a com.bugsnag.fixtures.keplertestapp.main")
   Maze::Runner.run_command("kepler device launch-app -a com.bugsnag.fixtures.keplertestapp.main")
 end
 
 When('I print error folder contents') do
-  Maze::Runner.run_command("kepler device run-cmd --command 'ls -la /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag/errors'")
+  # Only on the simulator
+  if $simulator
+    Maze::Runner.run_command("kepler device run-cmd --command 'ls -la /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag/errors'")
+  end
 end
 
 When('I copy error file') do
-  Maze::Runner.run_command("kepler device copy-from -d Simulator --source /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag/errors/* --destination maze_output/")
+  # Only on the simulator
+  if $simulator
+    Maze::Runner.run_command("kepler device copy-from -d Simulator --source /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag/errors/* --destination maze_output/")
+  end
 end
 
 Then("the exception {string} equals one of:") do |keypath, possible_values|
@@ -37,7 +43,11 @@ Then("the exception {string} equals one of:") do |keypath, possible_values|
 end
 
 def execute_command(action, scenario_name = '')
-  address = $address ? $address : '10.0.2.2:9339'
+  if $simulator
+    address = $address ? $address : '10.0.2.2:9339'
+  else
+    address = $address ? $address : "#{local_ip}:9339"
+  end
 
   command = {
     action: action,
@@ -54,4 +64,13 @@ def execute_command(action, scenario_name = '')
   count = 900
   sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
   raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
+end
+
+def local_ip
+  broadcast = `ifconfig | grep broadcast`.strip
+  address = /(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).+broadcast/.match(broadcast)
+  if address.nil?
+    raise 'Could not find local IP address'
+  end
+  address[1]
 end

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -1,35 +1,53 @@
+$simulator = ENV['SIMULATOR'] || ENV['ON_DEVICE'].nil?
+
 BeforeAll do
   Maze.config.enforce_bugsnag_integrity = true
 
-  # start the simulator
-  Maze::Runner.run_command("kepler device simulator start")
+  if $simulator
+    # start the simulator
+    Maze::Runner.run_command("kepler device simulator start")
 
-  # start the simulator log stream
-  Maze::Runner.run_command("kepler device start-log-stream -d Simulator > device.log", blocking: false)
-
-  # install the app
-  Maze::Runner.run_command("kepler device uninstall-app -d Simulator --appName com.bugsnag.fixtures.keplertestapp.main")
-  Maze::Runner.run_command("kepler device install-app -p ./features/fixtures/keplertestapp/build/vega-tv2023-aarch64-release/keplertestapp_aarch64.vpkg -d Simulator")
+    # start the simulator log stream
+    Maze::Runner.run_command("kepler device start-log-stream -d Simulator > device.log", blocking: false)
+  else
+    # start the device log stream
+    Maze::Runner.run_command("kepler device start-log-stream > device.log", blocking: false)
+  end
 end
 
 AfterAll do
   # stop the simulator
-  Maze::Runner.run_command("kepler device simulator stop")
+  Maze::Runner.run_command("kepler device simulator stop") if $simulator
 
   # move device logs to maze_output
   Maze::Runner.run_command("mv device.log maze_output")
 end
 
 Maze.hooks.before do
-  # launch the app
+  # reset the app, then launch it
+  Maze::Runner.run_command("kepler device uninstall-app --appName com.bugsnag.fixtures.keplertestapp.main")
+
+  if $simulator
+    Maze::Runner.run_command("kepler device install-app -p ./features/fixtures/keplertestapp/build/vega-tv2023-aarch64-release/keplertestapp_aarch64.vpkg -d Simulator")
+  else
+    Maze::Runner.run_command("kepler device install-app -p ./features/fixtures/keplertestapp/build/vega-tv2023-armv7-release/keplertestapp_armv7.vpkg")
+  end
+
   Maze::Runner.run_command("kepler device launch-app -a com.bugsnag.fixtures.keplertestapp.main")
 end
 
 Maze.hooks.after do
-  # terminate the app
-  Maze::Runner.run_command("kepler device copy-from -d Simulator --source /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag/utOutput.txt --destination maze_output/")
-  Maze::Runner.run_command("kepler device terminate-app -d Simulator --appName com.bugsnag.fixtures.keplertestapp.main")
-  Maze::Runner.run_command("kepler device run-cmd --command 'rm -r /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag'")
+  # Terminate the app
+  Maze::Runner.run_command("kepler device terminate-app --appName com.bugsnag.fixtures.keplertestapp.main")
+
+  # Only copy files from the simulator
+  if $simulator
+    Maze::Runner.run_command("kepler device copy-from --source /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag/utOutput.txt --destination maze_output/")
+    Maze::Runner.run_command("kepler device run-cmd --command 'rm -r /home/app_user/packages/com.bugsnag.fixtures.keplertestapp/data/bugsnag'")
+  end
+
+  # Uninstall the app
+  Maze::Runner.run_command("kepler device uninstall-app --appName com.bugsnag.fixtures.keplertestapp.main")
 end
 
 Before do


### PR DESCRIPTION
Adds some logic branching to allow the tests to run without too many alterations on a real test device (the IP baked into the `getCommand` logic in the fixture would still need updating).

In addition, adds an uninstall and reinstall between each test, which adds some additional runtime but ensures test files don't bleed into one another.

If someone could run the tests against the simulator (no environment setup required, just `bundle exec maze-runner`) and let me know that it successfully passes that would be great.