### PR TITLE
Add config option for disabling handling of native crashes

### DIFF
--- a/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.cpp
+++ b/packages/kepler-native/kepler/turbo-modules/BugsnagKeplerNative.cpp
@@ -81,13 +81,11 @@ BugsnagKeplerNative::configure(TM_API_NAMESPACE::JSObject config) {
   auto bsg_config = std::make_unique<Configuration>();
 
   std::string api_key = get_js_value<std::string>(config, "apikey", "");
-  TMWARN("[bugsnag] got api key " + api_key);
   bsg_config->api_key = api_key;
 
   std::string persistence_dir = get_js_value<std::string>(
       config, "persistenceDirectory", "/data/bugsnag");
   bsg_config->storage_dir = persistence_dir + "/errors";
-  TMWARN("[bugsnag] got persistence dir " + persistence_dir);
 
   if (bsg_config->max_breadcrumbs > BUGSNAG_CRUMBS_MAX) {
     bsg_config->max_breadcrumbs = BUGSNAG_CRUMBS_MAX;
@@ -97,7 +95,14 @@ BugsnagKeplerNative::configure(TM_API_NAMESPACE::JSObject config) {
   global_client = this->bugsnag;
   this->bugsnag->set_device_id(this->device_id);
 
-  install_signal_handlers();
+  auto enabled_errors = get_js_value<TM_API_NAMESPACE::JSObject>(
+      config, "enabledErrorTypes", TM_API_NAMESPACE::JSObject());
+  auto enabled_native_error =
+      get_js_value<bool>(enabled_errors, "nativeCrashes", true);
+
+  if (enabled_native_error) {
+    install_signal_handlers();
+  }
 
   auto result = TM_API_NAMESPACE::JSObject();
   result["app"] = createStaticApp();

--- a/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
+++ b/packages/kepler-native/src/turbo-modules/BugsnagKeplerNative.ts
@@ -1,11 +1,16 @@
-import type {KeplerTurboModule} from '@amzn/keplerscript-turbomodule-api'
-import {TurboModuleRegistry} from '@amzn/keplerscript-turbomodule-api'
+import type { KeplerTurboModule } from '@amzn/keplerscript-turbomodule-api'
+import { TurboModuleRegistry } from '@amzn/keplerscript-turbomodule-api'
 
 interface BugsnagConfiguration {
   dummyStrValue: string
   apikey: string
   appVersion?: string
   persistenceDirectory: string
+  enabledErrorTypes: {
+    unhandledExceptions: boolean
+    unhandledRejections: boolean
+    nativeCrashes: boolean
+  }
 }
 
 interface NativeStaticApp {

--- a/packages/kepler/lib/config.js
+++ b/packages/kepler/lib/config.js
@@ -6,6 +6,7 @@ import intRange from '@bugsnag/core/lib/validators/int-range'
 const iserror = require('iserror')
 
 const IS_PRODUCTION = typeof __DEV__ === 'undefined' || __DEV__ !== true
+const defaultErrorTypes = () => ({ unhandledExceptions: true, unhandledRejections: true, nativeCrashes: true })
 
 export const schema = {
   ...coreSchema,
@@ -38,6 +39,22 @@ export const schema = {
     defaultValue: () => true,
     message: 'should be a boolean',
     validate: (value) => typeof value === 'boolean'
+  },
+  enabledErrorTypes: {
+    defaultValue: () => defaultErrorTypes(),
+    message: 'should be an object containing the flags { unhandledExceptions:true|false, unhandledRejections:true|false, nativeCrashes: true|false }',
+    allowPartialObject: true,
+    validate: value => {
+      // ensure we have an object
+      if (typeof value !== 'object' || !value) return false
+      const providedKeys = Object.keys(value)
+      const defaultKeys = Object.keys(defaultErrorTypes())
+      // ensure it only has a subset of the allowed keys
+      if (providedKeys.filter(k => defaultKeys.includes(k)).length < providedKeys.length) return false
+      // ensure all of the values are boolean
+      if (Object.keys(value).filter(k => typeof value[k] !== 'boolean').length > 0) return false
+      return true
+    }
   }
 }
 

--- a/packages/kepler/lib/notifier.js
+++ b/packages/kepler/lib/notifier.js
@@ -46,7 +46,8 @@ export const Bugsnag = {
     const nativeStaticInfo = BugsnagKeplerNative.configure({
       dummyStrValue: opts.apiKey,
       apikey: opts.apiKey,
-      persistenceDirectory: bugsnag._config.persistenceDirectory
+      persistenceDirectory: bugsnag._config.persistenceDirectory,
+      enabledErrorTypes: bugsnag._config.enabledErrorTypes
     })
 
     const deviceStore = createDeviceStore(bugsnag._config.persistenceDirectory)

--- a/packages/kepler/types/bugsnag.d.ts
+++ b/packages/kepler/types/bugsnag.d.ts
@@ -6,6 +6,11 @@ interface KeplerConfig extends Config {
   maxPersistedEvents?: number
   maxPersistedSessions?: number
   persistUser?: boolean
+  enabledErrorTypes?: {
+    unhandledExceptions?: boolean
+    unhandledRejections?: boolean
+    nativeCrashes?: boolean
+  }
 }
 
 declare class KeplerClient extends Client {

--- a/test/features/fixtures/keplertestapp/src/scenarios/NativeCrashDisabledScenario.tsx
+++ b/test/features/fixtures/keplertestapp/src/scenarios/NativeCrashDisabledScenario.tsx
@@ -1,0 +1,34 @@
+import { BugsnagNativeUT } from '@bugsnag/kepler-native-ut'
+import Bugsnag, { type KeplerConfig } from '@bugsnag/kepler'
+import React, { useEffect } from 'react'
+import { Text, View } from "react-native"
+import { getStyles } from '../utils/defaultStyle'
+
+const config: Partial<KeplerConfig> = {
+  apiKey: '12345678901234567890123456789012',
+  enabledErrorTypes: {
+    nativeCrashes: false,
+  }
+}
+
+const App = () => {
+  const styles = getStyles()
+
+  useEffect(() => {
+    const utOutputFile = (config.persistenceDirectory ? config.persistenceDirectory : '/data/bugsnag') + '/utOutput.txt'
+    BugsnagNativeUT.configure(utOutputFile)
+    BugsnagNativeUT.manualAbortCrash()
+  }, [])
+
+  return (
+    <View style={styles.background}>
+      <View style={styles.headerContainer}>
+        <Text style={styles.headerText}>NativeCrashDisabledScenario</Text>
+      </View>
+    </View>
+  )
+}
+
+export default { App, config }
+
+

--- a/test/features/fixtures/keplertestapp/src/scenarios/index.ts
+++ b/test/features/fixtures/keplertestapp/src/scenarios/index.ts
@@ -36,3 +36,4 @@ export { default as NativeCrashFullConfigScenario } from './NativeCrashFullConfi
 export { default as NativeCrashAbortScenario } from './NativeCrashAbortScenario';
 export { default as NativeCrashNullptrScenario } from './NativeCrashNullptrScenario';
 export { default as NativeCrashExceptionScenario } from './NativeCrashExceptionScenario';
+export { default as NativeCrashDisabledScenario } from './NativeCrashDisabledScenario';

--- a/test/features/native.feature
+++ b/test/features/native.feature
@@ -91,6 +91,14 @@ Scenario: Run native crash - dereferencing nullptr
   And the exception "message" equals "Segmentation violation (invalid memory reference)"
   And the event "unhandled" is true
 
+Scenario: Run native crash - native errors disabled
+  When I run "NativeCrashDisabledScenario"
+  Then I should receive no errors
+  And I copy error file
+  And I restart the test fixture
+  And I start bugsnag for "NativeCrashDisabledScenario"
+  Then I should receive no errors
+
 # Scenario: Run native crash - throwing exception
 #   When I run "NativeCrashExceptionScenario"
 #   Then I should receive no errors

--- a/test/kepler-native-ut/kepler/turbo-modules/BugsnagNativeUT.cpp
+++ b/test/kepler-native-ut/kepler/turbo-modules/BugsnagNativeUT.cpp
@@ -55,6 +55,7 @@ TEST_CASE("testing the factorial function") {
 static void __attribute__((used)) somefakefunc(void) {}
 
 void BugsnagNativeUT::read_only_memory_crash() {
+  TMWARN("[bugsnag] triggered read only memory crash");
   // Write to a read-only page
   volatile char *ptr = (char *)somefakefunc;
   *ptr = 0;
@@ -62,10 +63,19 @@ void BugsnagNativeUT::read_only_memory_crash() {
 
 int *global_ptr = nullptr;
 
-void BugsnagNativeUT::nullptr_dereference_crash() { *global_ptr = 1; }
+void BugsnagNativeUT::nullptr_dereference_crash() {
+  TMWARN("[bugsnag] triggered nullptr dereference crash");
+  *global_ptr = 1;
+}
 
-void BugsnagNativeUT::manual_abort_crash() { abort(); }
+void BugsnagNativeUT::manual_abort_crash() {
+  TMWARN("[bugsnag] triggered manual abort crash");
+  abort();
+}
 
-void BugsnagNativeUT::throw_exception_crash() { throw std::bad_exception(); }
+void BugsnagNativeUT::throw_exception_crash() {
+  TMWARN("[bugsnag] triggered unhandled exception crash");
+  throw std::bad_exception();
+}
 
 } // namespace bugsnag


### PR DESCRIPTION
The native event capturing can be disabled by the JavaScript layer by setting a new errorTypes.nativeCrashes setting to false:

```
Bugsnag.start({
  enabledErrorTypes: {
    nativeCrashes: false,
  }
})
```