### PR TITLE
Fix publish config for packages (#87)

### DIFF
--- a/packages/vega-native/package.json
+++ b/packages/vega-native/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist",
     "react-native.config.js"

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "git+https://github.com/bugsnag/bugsnag-vega.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/bugsnag/bugsnag-vega/issues"
   },


### PR DESCRIPTION
## Goal

`@bugsnag/vega` and `@bugsnag/vega-native` were missing the required publish configuration.